### PR TITLE
Ensure that u2f actually works

### DIFF
--- a/src/PIResponse.php
+++ b/src/PIResponse.php
@@ -64,6 +64,12 @@ class PIResponse
         {
             $ret->messages = implode(", ", array_unique($map['detail']['messages'])) ?: "";
         }
+
+        if (isset($map['detail']['message']))
+        {
+            $ret->messages = $map['detail']['message'];
+        }
+
         if (isset($map['detail']['transaction_id']))
         {
             $ret->transactionID = $map['detail']['transaction_id'];
@@ -75,6 +81,19 @@ class PIResponse
         if (!empty($map['detail']['user']))
         {
             $attributes = $map['detail']['user'];
+            $detail = $map['detail'];
+
+            if (isset($attributes['username']))
+            {
+                $attributes['realm'] = $map['detail']['user-realm'] ?: "";
+                $attributes['resolver'] = $map['detail']['user-resolver'] ?: "";
+            }
+            $ret->detailAndAttributes = array("detail" => $detail, "attributes" => $attributes);
+        }
+
+        if (!empty($map['result']['value']['attributes']))
+        {
+            $attributes = $map['result']['value']['attributes'];
             $detail = $map['detail'];
 
             if (isset($attributes['username']))

--- a/src/PrivacyIDEA.php
+++ b/src/PrivacyIDEA.php
@@ -102,9 +102,9 @@ class PrivacyIDEA
             }
 
             //Call send_request function to handle an API Request using $parameters and return it.
-            $response = $this->sendRequest($params, array(''), 'POST', '/validate/check');
+            $response = $this->sendRequest($params, array(''), 'POST', '/validate/samlcheck');
 
-            //Return the response from /validate/check as PIResponse object
+            //Return the response from /validate/samlcheck as PIResponse object
             $ret = PIResponse::fromJSON($response, $this);
             if ($ret == null)
             {
@@ -250,7 +250,7 @@ class PrivacyIDEA
     }
 
     /**
-     * Sends a request to /validate/check with the data required to authenticate a WebAuthn token.
+     * Sends a request to /validate/samlcheck with the data required to authenticate a WebAuthn token.
      *
      * @param string $username
      * @param string $transactionID
@@ -273,7 +273,7 @@ class PrivacyIDEA
         if (!empty($username) || !empty($transactionID))
         {
 
-            // Compose standard validate/check params
+            // Compose standard validate/samlcheck params
             $params["user"] = $username;
             $params["pass"] = "";
             $params["transaction_id"] = $transactionID;
@@ -302,9 +302,9 @@ class PrivacyIDEA
 
             $header = array("Origin:" . $origin);
 
-            $response = $this->sendRequest($params, $header, 'POST', '/validate/check');
+            $response = $this->sendRequest($params, $header, 'POST', '/validate/samlcheck');
 
-            //Return the response from /validate/check as PIResponse object
+            //Return the response from /validate/samlcheck as PIResponse object
             $ret = PIResponse::fromJSON($response, $this);
 
             if ($ret == null)
@@ -322,7 +322,7 @@ class PrivacyIDEA
     }
 
     /**
-     * Sends a request to /validate/check with the data required to authenticate a U2F token.
+     * Sends a request to /validate/samlcheck with the data required to authenticate a U2F token.
      *
      * @param string $username
      * @param string $transactionID
@@ -343,7 +343,7 @@ class PrivacyIDEA
         if (!empty($username) || !empty($transactionID) || !empty($u2fSignResponse))
         {
 
-            // Compose standard validate/check params
+            // Compose standard validate/samlcheck params
             $params["user"] = $username;
             $params["pass"] = "";
             $params["transaction_id"] = $transactionID;
@@ -358,9 +358,9 @@ class PrivacyIDEA
             $params[CLIENTDATA] = $tmp["clientData"];
             $params[SIGNATUREDATA] = $tmp["signatureData"];
 
-            $response = $this->sendRequest($params, array(), 'POST', '/validate/check');
+            $response = $this->sendRequest($params, array(), 'POST', '/validate/samlcheck');
 
-            //Return the response from /validate/check as PIResponse object
+            //Return the response from /validate/samlcheck as PIResponse object
             $ret = PIResponse::fromJSON($response, $this);
 
             if ($ret == null)
@@ -432,7 +432,7 @@ class PrivacyIDEA
      * @param $params array request parameters in an array
      * @param $headers array headers fields in array
      * @param $httpMethod string
-     * @param $endpoint string endpoint of the privacyIDEA API (e.g. /validate/check)
+     * @param $endpoint string endpoint of the privacyIDEA API (e.g. /validate/samlcheck)
      * @return string returns string with response from server or an empty string if error occurs
      * @throws PIBadRequestException
      */


### PR DESCRIPTION
With `simplesamlphp-module-privacyidea` at v2.0 and the PHP SDK I couldn't get U2F authentication to run. The reason was that after I confirmed the token with my Yubikey, the page simply reloaded and I wasn't redirected to the service I wanted to use.

This happened because the `AuthSourceLoginHandler`[1] expects attributes to map onto SAML attributes to exist to assume the authentication to be complete which was not the case, so the auth itself succeeded, but the steps after were never performed.

I managed to work around it by changing two things:

* Use `/validate/samlcheck` rather than `/validate/check` against PI's REST API[2], only then the attributes appear to be returned.
* The relevant attributes are in `result.value.attributes` and need to be passed to `PIResponse::detailsAndAttributes`, only then the SimpleSAMLPHP module assumes the authentication to be complete.

[1] https://github.com/privacyidea/simplesamlphp-module-privacyidea/blob/v2.0/lib/Auth/Source/AuthSourceLoginHandler.php#L85-L98
[2] https://github.com/privacyidea/privacyidea/blob/v3.6.3/privacyidea/api/validate.py#L398-L415