### PR TITLE
chore: add license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "privacyidea/privacyidea-php-client",
   "description": "This is the privacyIDEA-PHP-Client. The library that will help you to connect your plugin to the privacyIDEA server using REST APIs.",
+  "license": "AGPL-3.0-or-later",
   "minimum-stability": "stable",
   "authors": [
     {


### PR DESCRIPTION
Add GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`) to composer.json, which is the same as in the LICENSE file.

You might also use `AGPL-3.0-only` to stick to v3.0.