### PR TITLE
fix: PSR-4 autoload without namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "autoload": {
       "psr-4": {
-          "PrivacyIdea\\PHPClient\\": "src"
+          "": "src"
       }
   },
   "repositories": [


### PR DESCRIPTION
The current classes don't have namespaces, so current composer autoload does not work.