### PR TITLE
Namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "autoload": {
       "psr-4": {
-          "PrivacyIdea\\PHPClient\\": "src"
+          "": "src"
       }
   },
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "autoload": {
       "psr-4": {
-          "": "src"
+          "PrivacyIdea\\PHPClient\\": "src"
       }
   },
   "repositories": [

--- a/src/PIBadRequestException.php
+++ b/src/PIBadRequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace PrivacyIdea\PHPClient;
+
 class PIBadRequestException extends \Exception {}
 {
 

--- a/src/PIChallenge.php
+++ b/src/PIChallenge.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace PrivacyIdea\PHPClient;
+
 class PIChallenge
 {
     /* @var string Token's type. */

--- a/src/PILog.php
+++ b/src/PILog.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace PrivacyIdea\PHPClient;
+
 /**
  * Interface PILog
  * Call the functions that collect debug and error messages

--- a/src/PIResponse.php
+++ b/src/PIResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace PrivacyIdea\PHPClient;
+
 class PIResponse
 {
     /* @var string All tokens messages which are sent by PI and can be used in UI to help user interact with service. */

--- a/src/PIResponse.php
+++ b/src/PIResponse.php
@@ -96,7 +96,10 @@ class PIResponse
                 $tmp->message = $challenge['message'];
                 $tmp->serial = $challenge['serial'];
                 $tmp->type = $challenge['type'];
-                $tmp->attributes = $challenge['attributes'];
+                if (isset($challenge['attributes']))
+                {
+                    $tmp->attributes = $challenge['attributes'];
+                }
 
                 if ($tmp->type === "webauthn")
                 {

--- a/src/PrivacyIDEA.php
+++ b/src/PrivacyIDEA.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace PrivacyIdea\PHPClient;
+
 const AUTHENTICATORDATA = "authenticatordata";
 const CLIENTDATA = "clientdata";
 const SIGNATUREDATA = "signaturedata";

--- a/src/SDK-Autoloader.php
+++ b/src/SDK-Autoloader.php
@@ -9,10 +9,13 @@ spl_autoload_register('autoLoader');
 
 function autoLoader($className)
 {
-    $fullPath = dirname(__FILE__) . "/" . $className . ".php";
+    $classNameParts = explode("\\");
+    $classNameOnly = $classNameParts[count($classNameParts) - 1];
+    $fullPath = dirname(__FILE__) . "/" . $classNameOnly . ".php";
     if (file_exists($fullPath))
     {
         require_once $fullPath;
+        class_alias($className, $classNameOnly, false);
         return true;
     } else
     {


### PR DESCRIPTION
To be merged after #9 and #11.

Introduce namespaces and adjust autoload accordingly. SDK-Autoloader should work as before thanks to `class_alias`.

BREAKING CHANGE: This changes how the classes are called from e.g. `PrivacyIDEA` or `\PrivacyIDEA` to `\PrivacyIdea\PHPClient\PrivacyIDEA`.