### PR TITLE
fix: namespace for autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "autoload": {
       "psr-4": {
-          "": "src"
+          "PrivacyIdea\\PHPClient\\": "src"
       }
   },
   "repositories": [


### PR DESCRIPTION
use the new namespace PrivacyIdea\PHPClient\ for PSR-4 autoload