### PR TITLE
Forward the source IP as value for "client" in sendRequest()

### DIFF
--- a/src/PrivacyIDEA.php
+++ b/src/PrivacyIDEA.php
@@ -42,6 +42,9 @@ class PrivacyIDEA
     /* @var string Realm for a service account to the privacyIDEA server. This is required to use the /validate/triggerchallenge endpoint. This is optional. */
     public $serviceAccountRealm = "";
 
+    /* @var bool Send the "client" parameter to allow using the original IP address in the privacyIDEA policies. */
+    public $forwardClientIP = false;
+
     /* @var object Implementation of the PILog interface. */
     public $logger = null;
 
@@ -422,18 +425,21 @@ class PrivacyIDEA
         assert('string' === gettype($httpMethod));
         assert('string' === gettype($endpoint));
 
-       /**
-       * Sending the "client" field allows us to use the original IP address in policies in Privacyidea.
-       */
-       $serverHeaders = $_SERVER;
-       foreach(array("X-Forwarded-For", "HTTP_X_FORWARDED_FOR", "REMOTE_ADDR") as $clientkey) {
-           if (array_key_exists($clientkey, $serverHeaders)) {
-               $client_ip = $serverHeaders[$clientkey];
-               $this->debugLog("Forwarding Client IP: " . $clientkey . ": " . $client_ip);
-               $params['client'] = $client_ip;
-               break;
-           }
-       }
+        // Add the client parameter if wished.
+        if ($this->forwardClientIP === true)
+        {
+            $serverHeaders = $_SERVER;
+            foreach (array("X-Forwarded-For", "HTTP_X_FORWARDED_FOR", "REMOTE_ADDR") as $clientKey)
+            {
+                if (array_key_exists($clientKey, $serverHeaders))
+                {
+                    $clientIP = $serverHeaders[$clientKey];
+                    $this->debugLog("Forwarding Client IP: " . $clientKey . ": " . $clientIP);
+                    $params['client'] = $clientIP;
+                    break;
+                }
+            }
+        }
         
         $this->debugLog("Sending " . http_build_query($params, '', ', ') . " to " . $endpoint);
 

--- a/src/PrivacyIDEA.php
+++ b/src/PrivacyIDEA.php
@@ -422,6 +422,19 @@ class PrivacyIDEA
         assert('string' === gettype($httpMethod));
         assert('string' === gettype($endpoint));
 
+       /**
+       * Sending the "client" field allows us to use the original IP address in policies in Privacyidea.
+       */
+       $serverHeaders = $_SERVER;
+       foreach(array("X-Forwarded-For", "HTTP_X_FORWARDED_FOR", "REMOTE_ADDR") as $clientkey) {
+           if (array_key_exists($clientkey, $serverHeaders)) {
+               $client_ip = $serverHeaders[$clientkey];
+               $this->debugLog("Forwarding Client IP: " . $clientkey . ": " . $client_ip);
+               $params['client'] = $client_ip;
+               break;
+           }
+       }
+        
         $this->debugLog("Sending " . http_build_query($params, '', ', ') . " to " . $endpoint);
 
         $completeUrl = $this->serverURL . $endpoint;

--- a/test/ValidateCheckTest.php
+++ b/test/ValidateCheckTest.php
@@ -32,6 +32,7 @@ class ValidateCheckTest extends TestCase implements PILog
         $this->pi->logger = $this;
         $this->pi->sslVerifyHost = false;
         $this->pi->sslVerifyPeer = false;
+        $this->pi->forwardClientIP = true;
         $this->pi->realm = "testRealm";
     }
 


### PR DESCRIPTION
Sending the "client" field allows us to use the original IP address in policies in Privacyidea.
Closes #17 